### PR TITLE
添加Beanstalkd支持

### DIFF
--- a/endpoint/beanstalkd/benstalkd.go
+++ b/endpoint/beanstalkd/benstalkd.go
@@ -1,0 +1,347 @@
+package beanstalkd
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/textproto"
+	"time"
+
+	"errors"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/beanstalkd/go-beanstalk"
+	"github.com/rulego/rulego/api/types"
+	endpointApi "github.com/rulego/rulego/api/types/endpoint"
+	"github.com/rulego/rulego/components/base"
+	"github.com/rulego/rulego/endpoint"
+	"github.com/rulego/rulego/endpoint/impl"
+	"github.com/rulego/rulego/utils/maps"
+)
+
+const (
+	Type                     = types.EndpointTypePrefix + "beanstalkdTubeset"
+	BEANSTALKD_DATA_MSG_TYPE = "BEANSTALKD_DATA"
+	DefaultTube              = "default"
+)
+
+// Endpoint 别名
+type Endpoint = BeanstalkdTubeSet
+
+var _ endpointApi.Endpoint = (*Endpoint)(nil)
+
+// 注册组件
+func init() {
+	_ = endpoint.Registry.Register(&Endpoint{})
+}
+
+// beanstalk Tubeset 配置
+type TubesetConfig struct {
+	// 服务器地址
+	Server string
+	// tube 列表
+	Tubesets []string
+	//Interval to read, supports cron expressions
+	//example: @every 1m (every 1 minute) 0 0 0 * * * (triggers at midnight)
+	Interval string
+	// 超时参数
+	Timeout string
+}
+
+type BeanstalkdTubeSet struct {
+	impl.BaseEndpoint
+	base.SharedNode[*beanstalk.TubeSet]
+	RuleConfig types.Config
+	// beanstalk Tubeset 相关配置
+	Config TubesetConfig
+	// 路由实例
+	Router endpointApi.Router
+	// beanstalk Tubesett实例
+	tubeset *beanstalk.TubeSet
+	// 定时任务实例
+	cronTask *cron.Cron
+	// 定时任务id
+	taskId cron.EntryID
+}
+
+// Type 组件类型
+func (x *BeanstalkdTubeSet) Type() string {
+	return Type
+}
+
+// New 创建组件实例
+func (x *BeanstalkdTubeSet) New() types.Node {
+	return &BeanstalkdTubeSet{
+		Config: TubesetConfig{
+			Server:   "127.0.0.1:11300",
+			Tubesets: []string{DefaultTube},
+			Interval: "@every 5s",
+			Timeout:  "5m",
+		},
+	}
+}
+
+// Init 初始化
+func (x *BeanstalkdTubeSet) Init(ruleConfig types.Config, configuration types.Configuration) error {
+	err := maps.Map2Struct(configuration, &x.Config)
+	x.RuleConfig = ruleConfig
+	_ = x.SharedNode.Init(x.RuleConfig, x.Type(), x.Config.Server, true, func() (*beanstalk.TubeSet, error) {
+		return x.initClient()
+	})
+	return err
+}
+
+// Destroy 销毁
+func (x *BeanstalkdTubeSet) Destroy() {
+	_ = x.Close()
+}
+
+func (x *BeanstalkdTubeSet) Close() error {
+	if x.taskId != 0 && x.cronTask != nil {
+		x.cronTask.Remove(x.taskId)
+	}
+	if x.cronTask != nil {
+		x.cronTask.Stop()
+	}
+	if x.tubeset != nil && x.tubeset.Conn != nil {
+		_ = x.tubeset.Conn.Close()
+		x.tubeset = nil
+	}
+	return nil
+}
+
+// Id 获取组件id
+func (x *BeanstalkdTubeSet) Id() string {
+	return x.Config.Server
+}
+
+// AddRouter 添加路由
+func (x *BeanstalkdTubeSet) AddRouter(router endpointApi.Router, params ...interface{}) (string, error) {
+	if router == nil {
+		return "", errors.New("router cannot be nil")
+	}
+	if x.Router != nil {
+		return "", errors.New("duplicate router")
+	}
+	x.Router = router
+	return router.GetId(), nil
+}
+
+// RemoveRouter 移除路由
+func (x *BeanstalkdTubeSet) RemoveRouter(routerId string, params ...interface{}) error {
+	x.Lock()
+	defer x.Unlock()
+	x.Router = nil
+	return nil
+}
+
+// Start 启动
+func (x *BeanstalkdTubeSet) Start() error {
+	var err error
+	if !x.SharedNode.IsInit() {
+		err = x.SharedNode.Init(x.RuleConfig, x.Type(), x.Config.Server, true, func() (*beanstalk.TubeSet, error) {
+			return x.initClient()
+		})
+	}
+	if x.cronTask != nil {
+		x.cronTask.Stop()
+	}
+	x.cronTask = cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger)), cron.WithLogger(cron.DefaultLogger))
+	eid, err := x.cronTask.AddFunc(x.Config.Interval, func() {
+		if x.Router != nil {
+			_ = x.reserve(x.Router)
+		}
+	})
+	x.taskId = eid
+	x.cronTask.Start()
+	return err
+}
+
+// reserve 预订Job
+func (x *BeanstalkdTubeSet) reserve(router endpointApi.Router) error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+	defer func() {
+		cancel()
+	}()
+	timeout, err := time.ParseDuration(x.Config.Timeout)
+	if err != nil {
+		x.Printf("parse duration error %v ", err)
+		return err
+	}
+	id, data, err := x.tubeset.Reserve(timeout)
+	if err != nil {
+		x.Printf("reserve job error %v ", err)
+		return err
+	}
+	stat, err := x.tubeset.Conn.StatsJob(id)
+	if err != nil {
+		x.Printf("get job stats error %v ", err)
+		return err
+	}
+	exchange := &endpoint.Exchange{
+		In: &RequestMessage{
+			body:  data,
+			stats: stat,
+		},
+		Out: &ResponseMessage{
+			body:  data,
+			stats: stat,
+		}}
+	x.DoProcess(ctx, router, exchange)
+	return nil
+}
+
+// Printf 打印日志
+func (x *BeanstalkdTubeSet) Printf(format string, v ...interface{}) {
+	if x.RuleConfig.Logger != nil {
+		x.RuleConfig.Logger.Printf(format, v...)
+	}
+}
+
+// initClient 初始化客户端
+func (x *BeanstalkdTubeSet) initClient() (*beanstalk.TubeSet, error) {
+	if x.tubeset != nil {
+		return x.tubeset, nil
+	} else {
+		_, cancel := context.WithTimeout(context.TODO(), 4*time.Second)
+		x.Lock()
+		defer func() {
+			cancel()
+			x.Unlock()
+		}()
+		if x.tubeset != nil {
+			return x.tubeset, nil
+		}
+
+		conn, err := beanstalk.Dial("tcp", x.Config.Server)
+		if err != nil {
+			return nil, err
+		}
+		x.tubeset = beanstalk.NewTubeSet(conn, x.Config.Tubesets...)
+		return x.tubeset, err
+	}
+}
+
+type RequestMessage struct {
+	headers    textproto.MIMEHeader
+	body       []byte
+	stats      map[string]string
+	msg        *types.RuleMsg
+	statusCode int
+	err        error
+}
+
+func (r *RequestMessage) Body() []byte {
+	return r.body
+}
+
+func (r *RequestMessage) Headers() textproto.MIMEHeader {
+	if r.headers == nil {
+		r.headers = make(map[string][]string)
+	}
+	return r.headers
+}
+
+func (r *RequestMessage) From() string {
+	return ""
+}
+
+// GetParam 不提供获取参数
+func (r *RequestMessage) GetParam(key string) string {
+	return ""
+}
+
+func (r *RequestMessage) SetMsg(msg *types.RuleMsg) {
+	r.msg = msg
+}
+func (r *RequestMessage) GetMsg() *types.RuleMsg {
+	if r.msg == nil {
+		//默认指定是JSON格式，如果不是该类型，请在process函数中修改
+		ruleMsg := types.NewMsg(0, BEANSTALKD_DATA_MSG_TYPE, types.JSON, r.stats, string(r.Body()))
+		r.msg = &ruleMsg
+	}
+	return r.msg
+}
+
+func (r *RequestMessage) SetStatusCode(statusCode int) {
+	r.statusCode = statusCode
+}
+func (r *RequestMessage) SetBody(body []byte) {
+	r.body = body
+}
+
+// SetError set error
+func (r *RequestMessage) SetError(err error) {
+	r.err = err
+}
+
+// GetError get error
+func (r *RequestMessage) GetError() error {
+	return r.err
+}
+
+type ResponseMessage struct {
+	headers    textproto.MIMEHeader
+	body       []byte
+	stats      map[string]string
+	msg        *types.RuleMsg
+	statusCode int
+	err        error
+}
+
+func (r *ResponseMessage) Body() []byte {
+	b, err := json.Marshal(r.body)
+	if err != nil {
+		log.Println(err)
+	}
+	return b
+}
+
+func (r *ResponseMessage) Headers() textproto.MIMEHeader {
+	if r.headers == nil {
+		r.headers = make(map[string][]string)
+	}
+	return r.headers
+}
+
+func (r *ResponseMessage) From() string {
+	return ""
+}
+
+// GetParam 不提供获取参数
+func (r *ResponseMessage) GetParam(key string) string {
+	return ""
+}
+
+func (r *ResponseMessage) SetMsg(msg *types.RuleMsg) {
+	r.msg = msg
+}
+func (r *ResponseMessage) GetMsg() *types.RuleMsg {
+	if r.msg == nil {
+		//默认指定是JSON格式，如果不是该类型，请在process函数中修改
+		ruleMsg := types.NewMsg(0, BEANSTALKD_DATA_MSG_TYPE, types.JSON, r.stats, string(r.Body()))
+		r.msg = &ruleMsg
+	}
+	return r.msg
+}
+
+func (r *ResponseMessage) SetStatusCode(statusCode int) {
+	r.statusCode = statusCode
+}
+func (r *ResponseMessage) SetBody(body []byte) {
+	r.body = body
+}
+func (r *ResponseMessage) getBody() []byte {
+	return r.body
+}
+
+// SetError set error
+func (r *ResponseMessage) SetError(err error) {
+	r.err = err
+}
+
+// GetError get error
+func (r *ResponseMessage) GetError() error {
+	return r.err
+}

--- a/endpoint/beanstalkd/benstalkd.go
+++ b/endpoint/beanstalkd/benstalkd.go
@@ -157,6 +157,9 @@ func (x *BeanstalkdTubeSet) reserve(router endpointApi.Router) error {
 		return err
 	}
 	x.conn, err = x.SharedNode.Get()
+	if err != nil {
+		return err
+	}
 	x.tubeset = beanstalk.NewTubeSet(x.conn, x.Config.Tubesets...)
 	id, data, err := x.tubeset.Reserve(timeout)
 	if err != nil {
@@ -214,11 +217,6 @@ func (x *BeanstalkdTubeSet) initClient() (*beanstalk.Conn, error) {
 		x.tubeset = beanstalk.NewTubeSet(x.conn, x.Config.Tubesets...)
 		return x.conn, err
 	}
-}
-
-// use tube
-func (x *BeanstalkdTubeSet) Use(tube string) {
-	x.conn.Tube.Name = tube
 }
 
 type RequestMessage struct {

--- a/endpoint/beanstalkd/benstalkd.go
+++ b/endpoint/beanstalkd/benstalkd.go
@@ -41,7 +41,7 @@ type TubesetConfig struct {
 	// tube 列表
 	Tubesets []string
 	// 超时参数
-	Timeout string
+	Timeout int64
 }
 
 type BeanstalkdTubeSet struct {
@@ -69,7 +69,7 @@ func (x *BeanstalkdTubeSet) New() types.Node {
 		Config: TubesetConfig{
 			Server:   "127.0.0.1:11300",
 			Tubesets: []string{DefaultTube},
-			Timeout:  "5m",
+			Timeout:  300,
 		},
 	}
 }
@@ -151,11 +151,8 @@ func (x *BeanstalkdTubeSet) reserve(router endpointApi.Router) error {
 		cancel()
 	}()
 
-	timeout, err := time.ParseDuration(x.Config.Timeout)
-	if err != nil {
-		x.Printf("parse duration error %v ", err)
-		return err
-	}
+	var err error
+	timeout := time.Duration(x.Config.Timeout) * time.Second
 	x.conn, err = x.SharedNode.Get()
 	if err != nil {
 		return err

--- a/external/beanstalkd/tube_node.go
+++ b/external/beanstalkd/tube_node.go
@@ -1,0 +1,262 @@
+package beanstalkd
+
+import (
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/beanstalkd/go-beanstalk"
+	"github.com/rulego/rulego"
+	"github.com/rulego/rulego/api/types"
+	"github.com/rulego/rulego/components/base"
+	"github.com/rulego/rulego/utils/maps"
+	"github.com/rulego/rulego/utils/str"
+)
+
+const (
+	Put         = "Put"
+	PeekReady   = "PeekReady"
+	PeekDelayed = "PeekDelayed"
+	PeekBuried  = "PeekBuried"
+	Kick        = "Kick"
+	Stat        = "Stat"
+	Pause       = "Pause"
+
+	//优先级
+	PriHigh   uint32 = 1
+	PriNormal uint32 = 2
+	PriLow    uint32 = 3
+
+	DefaultPri   = PriLow
+	DefaultDelay = time.Second * 0
+	DefaultTime  = time.Second * 5
+	DefaultBound = 10
+)
+
+// 注册节点
+func init() {
+	_ = rulego.Registry.Register(&TubeNode{})
+}
+
+// TubeConfiguration 节点配置
+type TubeConfiguration struct {
+	// 服务器地址
+	Server string
+	// Tube名称
+	Tube string
+	// 命令：Put、PeekReady、PeekDelayed、PeekBuried、Kick、Stat、Pause
+	Cmd string
+	// Put命令参数pri 允许使用 ${} 占位符变量
+	PutPri string
+	// Put命令参数delay 允许使用 ${} 占位符变量
+	PutDelay string
+	// Put命令参数ttr 允许使用 ${} 占位符变量
+	PutTTR string
+	// Kick命令参数bound 允许使用 ${} 占位符变量
+	KickBound string
+	// Pause命令参数time 允许使用 ${} 占位符变量
+	PauseTime string
+}
+
+// TubeNode 客户端节点，
+// 成功：转向Success链，发送消息执行结果存放在msg.Data
+// 失败：转向Failure链
+type TubeNode struct {
+	base.SharedNode[*beanstalk.Tube]
+	//节点配置
+	Config            TubeConfiguration
+	tube              *beanstalk.Tube
+	putPriTemplate    str.Template
+	putDelayTemplate  str.Template
+	putTTRTemplate    str.Template
+	kickBoundTemplate str.Template
+	pauseTimeTemplate str.Template
+}
+
+// Type 返回组件类型
+func (x *TubeNode) Type() string {
+	return "x/beanstalkdTube"
+}
+
+// New 默认参数
+func (x *TubeNode) New() types.Node {
+	return &TubeNode{Config: TubeConfiguration{
+		Server: "127.0.0.1:11300",
+		Tube:   "default",
+		Cmd:    Stat,
+	}}
+}
+
+// Init 初始化组件
+func (x *TubeNode) Init(ruleConfig types.Config, configuration types.Configuration) error {
+	err := maps.Map2Struct(configuration, &x.Config)
+	//初始化模板
+	x.putPriTemplate = str.NewTemplate(x.Config.PutPri)
+	x.putDelayTemplate = str.NewTemplate(x.Config.PutDelay)
+	x.putTTRTemplate = str.NewTemplate(x.Config.PutTTR)
+	x.kickBoundTemplate = str.NewTemplate(x.Config.KickBound)
+	x.pauseTimeTemplate = str.NewTemplate(x.Config.PauseTime)
+	if err == nil {
+		//初始化客户端
+		err = x.SharedNode.Init(ruleConfig, x.Type(), x.Config.Server, true, func() (*beanstalk.Tube, error) {
+			return x.initClient()
+		})
+	}
+	return err
+}
+
+// OnMsg 处理消息
+func (x *TubeNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
+	var (
+		err   error
+		id    uint64
+		body  []byte
+		count int
+		data  map[string]any = make(map[string]any)
+		pri   uint32         = DefaultPri
+		delay time.Duration  = DefaultDelay
+		ttr   time.Duration  = DefaultTime
+		pause time.Duration  = DefaultTime
+		bound int            = DefaultBound
+	)
+	evn := base.NodeUtils.GetEvnAndMetadata(ctx, msg)
+	switch x.Config.Cmd {
+	case Put:
+		if !x.putPriTemplate.IsNotVar() {
+			tmp := x.putPriTemplate.Execute(evn)
+			ti, err := strconv.Atoi(tmp)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		} else if len(x.Config.PutPri) > 0 {
+			ti, err := strconv.Atoi(x.Config.PutPri)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		}
+
+		if !x.putDelayTemplate.IsNotVar() {
+			tmp := x.putDelayTemplate.Execute(evn)
+			delay, err = time.ParseDuration(tmp)
+		} else if len(x.Config.PutDelay) > 0 {
+			delay, err = time.ParseDuration(x.Config.PutDelay)
+		}
+		if err != nil {
+			break
+		}
+		if !x.putTTRTemplate.IsNotVar() {
+			tmp := x.putTTRTemplate.Execute(evn)
+			ttr, err = time.ParseDuration(tmp)
+		} else if len(x.Config.PutTTR) > 0 {
+			ttr, err = time.ParseDuration(x.Config.PutTTR)
+		}
+		if err != nil {
+			break
+		}
+		id, err = x.tube.Put([]byte(msg.Data), pri, delay, ttr)
+		if err != nil {
+			break
+		}
+		data["id"] = id
+	case PeekReady:
+		id, body, err = x.tube.PeekReady()
+		if err != nil {
+			break
+		}
+		data["id"] = id
+		data["body"] = string(body)
+	case PeekDelayed:
+		id, body, err = x.tube.PeekDelayed()
+		if err != nil {
+			break
+		}
+		data["id"] = id
+		data["body"] = string(body)
+	case PeekBuried:
+		id, body, err = x.tube.PeekBuried()
+		if err != nil {
+			break
+		}
+		data["id"] = id
+		data["body"] = string(body)
+	case Kick:
+		if !x.kickBoundTemplate.IsNotVar() {
+			tmp := x.kickBoundTemplate.Execute(evn)
+			bound, err = strconv.Atoi(tmp)
+		} else if len(x.Config.KickBound) > 0 {
+			bound, err = strconv.Atoi(x.Config.KickBound)
+		}
+		if err != nil {
+			break
+		}
+		count, err = x.tube.Kick(bound)
+		if err != nil {
+			break
+		}
+		data["count"] = count
+	case Stat:
+		if !x.pauseTimeTemplate.IsNotVar() {
+			tmp := x.pauseTimeTemplate.Execute(evn)
+			pause, err = time.ParseDuration(tmp)
+		} else if len(x.Config.PauseTime) > 0 {
+			pause, err = time.ParseDuration(x.Config.PauseTime)
+		}
+		if err != nil {
+			break
+		}
+		var stat map[string]string
+		stat, err = x.tube.Stats()
+		for k, v := range stat {
+			data[k] = v
+		}
+	case Pause:
+		err = x.tube.Pause(pause)
+	default:
+		err = errors.New("Unknown Command")
+	}
+	if err != nil {
+		ctx.TellFailure(msg, err)
+	} else {
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			ctx.TellFailure(msg, err)
+			return
+		}
+		msg.Data = str.ToString(bytes)
+		ctx.TellSuccess(msg)
+	}
+}
+
+// Destroy 销毁组件
+func (x *TubeNode) Destroy() {
+	if x.tube != nil {
+		_ = x.tube.Conn.Close()
+	}
+}
+
+// Printf 打印日志
+func (x *TubeNode) Printf(format string, v ...interface{}) {
+	if x.RuleConfig.Logger != nil {
+		x.RuleConfig.Logger.Printf(format, v...)
+	}
+}
+
+// 初始化连接
+func (x *TubeNode) initClient() (*beanstalk.Tube, error) {
+	if x.tube != nil {
+		return x.tube, nil
+	} else {
+		x.Locker.Lock()
+		defer x.Locker.Unlock()
+		if x.tube != nil {
+			return x.tube, nil
+		}
+		var err error
+		conn, err := beanstalk.Dial("tcp", x.Config.Server)
+		x.tube = beanstalk.NewTube(conn, x.Config.Tube)
+		return x.tube, err
+	}
+}

--- a/external/beanstalkd/tube_node.go
+++ b/external/beanstalkd/tube_node.go
@@ -145,10 +145,11 @@ func (x *TubeNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 	case Put:
 		id, err = x.tube.Put([]byte(params.Body), params.Pri, params.Delay, params.Ttr)
 		if err != nil {
+			x.Printf("put job with err: %s", err)
 			break
 		}
 		data["id"] = id
-		x.Printf("put job id:%d to %s  with err: %s", id, x.tube.Conn.Tube.Name, err)
+		x.Printf("put job id:%d to %s ", id, x.tube.Conn.Tube.Name)
 	case PeekReady:
 		id, body, err = x.tube.PeekReady()
 		if err != nil {
@@ -201,6 +202,15 @@ func (x *TubeNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 			return
 		}
 		msg.Data = str.ToString(bytes)
+		if id > 0 {
+			stat, err = x.tube.Conn.StatsJob(id)
+			if err != nil {
+				x.Printf("get job stats error %v ", err)
+				ctx.TellFailure(msg, err)
+				return
+			}
+			msg.Metadata = stat
+		}
 		ctx.TellSuccess(msg)
 	}
 }

--- a/external/beanstalkd/tube_node.go
+++ b/external/beanstalkd/tube_node.go
@@ -140,7 +140,14 @@ func (x *TubeNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 	params, err = x.getParams(ctx, msg)
 
 	// use tube
-	x.Use(params.Tube)
+	x.conn, err = x.SharedNode.Get()
+	if err != nil {
+		ctx.TellFailure(msg, err)
+		return
+	}
+	x.Printf("conn :%v ", x.conn)
+	x.tube = beanstalk.NewTube(x.conn, params.Tube)
+	x.conn.Tube.Name = params.Tube
 	if err != nil {
 		ctx.TellFailure(msg, err)
 		return
@@ -346,11 +353,4 @@ func (x *TubeNode) initClient() (*beanstalk.Conn, error) {
 		x.tube = beanstalk.NewTube(x.conn, DefaultTube)
 		return x.conn, err
 	}
-}
-
-// use tube
-func (x *TubeNode) Use(tube string) {
-	x.conn, _ = x.SharedNode.Get()
-	x.tube = beanstalk.NewTube(x.conn, tube)
-	x.conn.Tube.Name = tube
 }

--- a/external/beanstalkd/worker_node.go
+++ b/external/beanstalkd/worker_node.go
@@ -117,14 +117,14 @@ func (x *WorkerNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 		stat   map[string]string
 	)
 	params, err = x.getParams(ctx, msg)
+	// use tube
 	x.conn, err = x.SharedNode.Get()
 	if err != nil {
 		ctx.TellFailure(msg, err)
 		return
 	}
 	x.Printf("conn :%v ", x.conn)
-	// use tube
-	x.Use(params.Tube)
+	x.conn.Tube.Name = params.Tube
 	switch x.Config.Cmd {
 	case Delete:
 		if params.Id == 0 {
@@ -301,9 +301,4 @@ func (x *WorkerNode) initClient() (*beanstalk.Conn, error) {
 		x.conn.Tube = *beanstalk.NewTube(x.conn, DefaultTube)
 		return x.conn, err
 	}
-}
-
-// use tube
-func (x *WorkerNode) Use(tube string) {
-	x.conn.Tube.Name = tube
 }

--- a/external/beanstalkd/worker_node.go
+++ b/external/beanstalkd/worker_node.go
@@ -1,0 +1,250 @@
+package beanstalkd
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/beanstalkd/go-beanstalk"
+	"github.com/rulego/rulego"
+	"github.com/rulego/rulego/api/types"
+	"github.com/rulego/rulego/components/base"
+	"github.com/rulego/rulego/utils/maps"
+	"github.com/rulego/rulego/utils/str"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	Delete     = "Delete"
+	Release    = "Release"
+	Bury       = "Bury"
+	KickJob    = "KickJob"
+	Touch      = "Touch"
+	Peek       = "Peek"
+	ReserveJob = "ReserveJob"
+	StatsJob   = "StatsJob"
+	Stats      = "Stats"
+	ListTubes  = "ListTubes"
+)
+
+// 注册节点
+func init() {
+	_ = rulego.Registry.Register(&WorkerNode{})
+}
+
+// WorkerConfiguration 节点配置
+type WorkerConfiguration struct {
+	// 服务器地址
+	Server string
+	// Tube名称
+	Tube string
+	// 命令：Delete Release Bury KickJob Touch Peek ReserveJob  StatsJob Stats  ListTubes
+	Cmd string
+	// JobId  允许使用 ${} 占位符变量
+	JobId string
+	// Put命令参数pri 允许使用 ${} 占位符变量
+	PutPri string
+	// Put命令参数delay 允许使用 ${} 占位符变量
+	PutDelay string
+}
+
+// WorkerNode 客户端节点，
+// 成功：转向Success链，发送消息执行结果存放在msg.Data
+// 失败：转向Failure链
+type WorkerNode struct {
+	base.SharedNode[*beanstalk.Conn]
+	//节点配置
+	Config           WorkerConfiguration
+	conn             *beanstalk.Conn
+	jobIdTemplate    str.Template
+	putPriTemplate   str.Template
+	putDelayTemplate str.Template
+}
+
+// Type 返回组件类型
+func (x *WorkerNode) Type() string {
+	return "x/beanstalkdWorker"
+}
+
+// New 默认参数
+func (x *WorkerNode) New() types.Node {
+	return &WorkerNode{Config: WorkerConfiguration{
+		Server: "127.0.0.1:11300",
+		Tube:   "default",
+		Cmd:    Stats,
+	}}
+}
+
+// Init 初始化组件
+func (x *WorkerNode) Init(ruleConfig types.Config, configuration types.Configuration) error {
+	err := maps.Map2Struct(configuration, &x.Config)
+	//初始化模板
+	x.putPriTemplate = str.NewTemplate(x.Config.PutPri)
+	x.putDelayTemplate = str.NewTemplate(x.Config.PutDelay)
+	x.jobIdTemplate = str.NewTemplate(x.Config.JobId)
+	if err == nil {
+		//初始化客户端
+		err = x.SharedNode.Init(ruleConfig, x.Type(), x.Config.Server, true, func() (*beanstalk.Conn, error) {
+			return x.initClient()
+		})
+	}
+	return err
+}
+
+// OnMsg 处理消息
+func (x *WorkerNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
+	var (
+		err   error
+		id    uint64 = 0
+		body  []byte
+		tubes []string          = make([]string, 0)
+		data  map[string]string = make(map[string]string)
+		pri                     = DefaultPri
+		delay time.Duration     = DefaultDelay
+	)
+	evn := base.NodeUtils.GetEvnAndMetadata(ctx, msg)
+	if !x.jobIdTemplate.IsNotVar() {
+		tmp := x.jobIdTemplate.Execute(evn)
+		id, err = strconv.ParseUint(tmp, 10, 64)
+	}
+
+	switch x.Config.Cmd {
+	case Delete:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		err = x.conn.Delete(id)
+	case Release:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		if !x.putPriTemplate.IsNotVar() {
+			tmp := x.putPriTemplate.Execute(evn)
+			ti, err := strconv.Atoi(tmp)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		} else if len(x.Config.PutPri) > 0 {
+			ti, err := strconv.Atoi(x.Config.PutPri)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		}
+		if !x.putDelayTemplate.IsNotVar() {
+			tmp := x.putDelayTemplate.Execute(evn)
+			delay, err = time.ParseDuration(tmp)
+		} else if len(x.Config.PutDelay) > 0 {
+			delay, err = time.ParseDuration(x.Config.PutDelay)
+		}
+		if err != nil {
+			break
+		}
+		err = x.conn.Release(id, pri, delay)
+	case Bury:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		if !x.putPriTemplate.IsNotVar() {
+			tmp := x.putPriTemplate.Execute(evn)
+			ti, err := strconv.Atoi(tmp)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		} else if len(x.Config.PutPri) > 0 {
+			ti, err := strconv.Atoi(x.Config.PutPri)
+			if err != nil {
+				break
+			}
+			pri = uint32(ti)
+		}
+		err = x.conn.Bury(id, pri)
+	case KickJob:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		err = x.conn.KickJob(id)
+	case Touch:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		err = x.conn.Touch(id)
+	case Peek:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		body, err = x.conn.Peek(id)
+		data["body"] = string(body)
+	case ReserveJob:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		body, err = x.conn.ReserveJob(id)
+		data["body"] = string(body)
+	case StatsJob:
+		if id == 0 {
+			err = errors.New("id is empty")
+			break
+		}
+		data, err = x.conn.StatsJob(id)
+	case Stats:
+		data, err = x.conn.Stats()
+	case ListTubes:
+		tubes, err = x.conn.ListTubes()
+		data["tubes"] = strings.Join(tubes, ",")
+	default:
+		err = errors.New("Unknown Command")
+	}
+	if err != nil {
+		ctx.TellFailure(msg, err)
+	} else {
+		bytes, err := json.Marshal(data)
+		if err != nil {
+			ctx.TellFailure(msg, err)
+			return
+		}
+		msg.Data = str.ToString(bytes)
+		ctx.TellSuccess(msg)
+	}
+}
+
+// Destroy 销毁组件
+func (x *WorkerNode) Destroy() {
+	if x.conn != nil {
+		_ = x.conn.Close()
+	}
+}
+
+// Printf 打印日志
+func (x *WorkerNode) Printf(format string, v ...interface{}) {
+	if x.RuleConfig.Logger != nil {
+		x.RuleConfig.Logger.Printf(format, v...)
+	}
+}
+
+// 初始化连接
+func (x *WorkerNode) initClient() (*beanstalk.Conn, error) {
+	if x.conn != nil {
+		return x.conn, nil
+	} else {
+		x.Locker.Lock()
+		defer x.Locker.Unlock()
+		if x.conn != nil {
+			return x.conn, nil
+		}
+		var err error
+		conn, err := beanstalk.Dial("tcp", x.Config.Server)
+		conn.Tube = *beanstalk.NewTube(conn, x.Config.Tube)
+		x.conn = conn
+		return x.conn, err
+	}
+}

--- a/external/beanstalkd/worker_node.go
+++ b/external/beanstalkd/worker_node.go
@@ -114,6 +114,7 @@ func (x *WorkerNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 		tubes  []string          = make([]string, 0)
 		data   map[string]string = make(map[string]string)
 		params *WorkerMsgParams
+		stat   map[string]string
 	)
 	params, err = x.getParams(ctx, msg)
 	// use tube
@@ -196,6 +197,15 @@ func (x *WorkerNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 			return
 		}
 		msg.Data = str.ToString(bytes)
+		if params.Id > 0 {
+			stat, err = x.conn.StatsJob(params.Id)
+			if err != nil {
+				x.Printf("get job stats error %v ", err)
+				ctx.TellFailure(msg, err)
+				return
+			}
+			msg.Metadata = stat
+		}
 		ctx.TellSuccess(msg)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM/sarama v1.43.2
 	github.com/WuKongIM/WuKongIMGoProto v1.0.21
 	github.com/WuKongIM/WuKongIMGoSDK v1.0.0
+	github.com/beanstalkd/go-beanstalk v0.2.0
 	github.com/expr-lang/expr v1.16.9
 	github.com/fullstorydev/grpcurl v1.9.1
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
## 主要功能

1.添加Tubeset Endpoint ，对应Beanstalkd Tubeset中的reserver操作，支持从多个tube队列订阅Job交给后续节点处理。
2.添加Worker和Tube两类Node：
    Worker Node作为消费端支持Delete、Release、Bury、KickJob、Touch、Peek、ReserveJob、StatsJob、Stats、ListTubes。
    Tube Node面向单个队列，支持Put、PeekReady、PeekDelayed、PeekBuried、Kick、Stat、Pause。

### Tubeset Endpoint
#### 配置项

> // 服务器地址 支持全局共享连接，通过ref://引用
> 	Server string
> 	// tube 列表
> 	Tubesets []string
> 	// 超时参数
> 	Timeout string

#### 示例

> {
> 	"ruleChain": {
> 		"id": "TCh3Jts0IroQ",
> 		"name": "Beastalkd Enpoint测试",
> 		"debugMode": false,
> 		"root": true,
> 		"disabled": false,
> 		"additionalInfo": {
> 			"createTime": "2025/01/16 09:34:19",
> 			"description": "",
> 			"layoutX": "280",
> 			"layoutY": "280",
> 			"message": "the rule chain has been disabled",
> 			"updateTime": "2025/01/16 21:47:46",
> 			"username": "admin"
> 		}
> 	},
> 	"metadata": {
> 		"endpoints": [
> 			{
> 				"id": "node_2",
> 				"additionalInfo": {
> 					"layoutX": 480,
> 					"layoutY": 380
> 				},
> 				"type": "endpoint/beanstalkdTubeset",
> 				"name": "Pop Job",
> 				"debugMode": false,
> 				"configuration": {
> 					"server": "ref://local_beanstalkdWorker",
> 					"timeout": "5m",
> 					"tubesets": [
> 						"foo",
> 						"bar"
> 					]
> 				},
> 				"processors": null,
> 				"routers": [
> 					{
> 						"id": "5XCMosX5GVY3",
> 						"params": [],
> 						"from": {
> 							"path": "*",
> 							"configuration": null,
> 							"processors": []
> 						},
> 						"to": {
> 							"path": "TCh3Jts0IroQ:node_4",
> 							"configuration": null,
> 							"wait": false,
> 							"processors": []
> 						}
> 					}
> 				]
> 			}
> 		],
> 		"nodes": [
> 			{
> 				"id": "node_4",
> 				"additionalInfo": {
> 					"layoutX": 780,
> 					"layoutY": 320
> 				},
> 				"type": "log",
> 				"name": "Log",
> 				"debugMode": true,
> 				"configuration": {
> 					"jsScript": "return 'Incoming message:\\n' + JSON.stringify(msg) + '\\nIncoming metadata:\\n' + JSON.stringify(metadata);"
> 				}
> 			},
> 			{
> 				"id": "node_9",
> 				"additionalInfo": {
> 					"layoutX": 1040,
> 					"layoutY": 240
> 				},
> 				"type": "x/beanstalkdWorker",
> 				"name": "Del",
> 				"debugMode": true,
> 				"configuration": {
> 					"cmd": "Delete",
> 					"jobId": "${id}",
> 					"server": "ref://local_beanstalkdWorker",
> 					"tube": "${tube}"
> 				}
> 			}
> 		],
> 		"connections": [
> 			{
> 				"fromId": "node_4",
> 				"toId": "node_9",
> 				"type": "Success"
> 			}
> 		]
> 	}
> }
> 

### Worker Node
#### 配置项

> 	// 服务器地址
> 	Server string
> 	// Tube名称 允许使用 ${} 占位符变量
> 	Tube string
> 	// 命令名称，支持Delete Release Bury KickJob Touch Peek ReserveJob  StatsJob Stats  ListTubes
> 	Cmd string
> 	// JobId  允许使用 ${} 占位符变量
> 	JobId string
> 	// 优先级: pri 允许使用 ${} 占位符变量
> 	Pri string
> 	// 延迟时间: delay 允许使用 ${} 占位符变量
> 	Delay string

### Tube Node
#### 配置项
// 服务器地址

> 	Server string
> 	// Tube名称 允许使用 ${} 占位符变量
> 	Tube string
> 	// 命令名称，支持Put、PeekReady、PeekDelayed、PeekBuried、Kick、Stat、Pause
> 	Cmd string
> 	// 消息内容：body 允许使用 ${} 占位符变量
> 	Body string
> 	// 优先级：pri 允许使用 ${} 占位符变量
> 	Pri string
> 	// 延迟时间：delay 允许使用 ${} 占位符变量
> 	Delay string
> 	// 最大执行秒数:ttr 允许使用 ${} 占位符变量
> 	Ttr string
> 	// Kick命令参数bound 允许使用 ${} 占位符变量
> 	KickBound string
> 	// Pause命令参数time 允许使用 ${} 占位符变量
> 	PauseTime string

#### 示例

> {
> 	"ruleChain": {
> 		"id": "f5G9y8GzpgDY",
> 		"name": "Beanstalkd  Node 测试",
> 		"debugMode": false,
> 		"root": true,
> 		"disabled": false,
> 		"additionalInfo": {
> 			"createTime": "2025/01/15 21:50:47",
> 			"description": "",
> 			"layoutX": "700",
> 			"layoutY": "100",
> 			"message": "the rule chain has been disabled",
> 			"updateTime": "2025/01/17 14:31:16",
> 			"username": "admin"
> 		}
> 	},
> 	"metadata": {
> 		"endpoints": [
> 			{
> 				"id": "node_2",
> 				"additionalInfo": {
> 					"layoutX": 450,
> 					"layoutY": 160
> 				},
> 				"type": "endpoint/http",
> 				"name": "API",
> 				"debugMode": false,
> 				"configuration": {
> 					"allowCors": true,
> 					"server": ":6333"
> 				},
> 				"processors": null,
> 				"routers": [
> 					{
> 						"id": "KOUXvKLg1Ml2",
> 						"params": [
> 							"POST"
> 						],
> 						"from": {
> 							"path": "/msg/add",
> 							"configuration": null,
> 							"processors": [
> 								"setJsonDataType"
> 							]
> 						},
> 						"to": {
> 							"path": "f5G9y8GzpgDY:node_4",
> 							"configuration": null,
> 							"wait": true,
> 							"processors": [
> 								"responseToBody",
> 								"metadataToHeaders"
> 							]
> 						}
> 					},
> 					{
> 						"id": "Ud6fjHltHyKg",
> 						"params": [
> 							"POST"
> 						],
> 						"from": {
> 							"path": "/msg/del",
> 							"configuration": null,
> 							"processors": [
> 								"setJsonDataType"
> 							]
> 						},
> 						"to": {
> 							"path": "f5G9y8GzpgDY:node_8",
> 							"configuration": null,
> 							"wait": true,
> 							"processors": [
> 								"responseToBody",
> 								"metadataToHeaders"
> 							]
> 						}
> 					},
> 					{
> 						"id": "HlgiXu67EWBX",
> 						"params": [
> 							"POST"
> 						],
> 						"from": {
> 							"path": "/msg/release",
> 							"configuration": null,
> 							"processors": [
> 								"setJsonDataType"
> 							]
> 						},
> 						"to": {
> 							"path": "f5G9y8GzpgDY:node_15",
> 							"configuration": null,
> 							"wait": true,
> 							"processors": [
> 								"responseToBody"
> 							]
> 						}
> 					}
> 				]
> 			}
> 		],
> 		"nodes": [
> 			{
> 				"id": "node_4",
> 				"additionalInfo": {
> 					"layoutX": 950,
> 					"layoutY": 160
> 				},
> 				"type": "x/beanstalkdTube",
> 				"name": "Put",
> 				"debugMode": true,
> 				"configuration": {
> 					"body": "${msg.body}",
> 					"cmd": "Put",
> 					"putBody": "${msg.body}",
> 					"server": "ref://local_beanstalkdTube",
> 					"tube": "${msg.tube}"
> 				}
> 			},
> 			{
> 				"id": "node_8",
> 				"additionalInfo": {
> 					"layoutX": 900,
> 					"layoutY": 400
> 				},
> 				"type": "x/beanstalkdWorker",
> 				"name": "Del",
> 				"debugMode": true,
> 				"configuration": {
> 					"cmd": "Delete",
> 					"jobId": "${msg.id}",
> 					"server": "ref://local_beanstalkdWorker",
> 					"tube": "${msg.tube}"
> 				}
> 			},
> 			{
> 				"id": "node_13",
> 				"additionalInfo": {
> 					"layoutX": 850,
> 					"layoutY": 550
> 				},
> 				"type": "x/beanstalkdWorker",
> 				"name": "Release",
> 				"debugMode": true,
> 				"configuration": {
> 					"cmd": "Release",
> 					"jobId": "${id}",
> 					"server": "ref://local_beanstalkdWorker",
> 					"tube": "${tube}"
> 				}
> 			},
> 			{
> 				"id": "node_15",
> 				"additionalInfo": {
> 					"layoutX": 500,
> 					"layoutY": 530
> 				},
> 				"type": "x/beanstalkdWorker",
> 				"name": "ReserveJob",
> 				"debugMode": true,
> 				"configuration": {
> 					"cmd": "ReserveJob",
> 					"jobId": "${msg.id}",
> 					"server": "ref://local_beanstalkdWorker",
> 					"tube": "${msg.tube}"
> 				}
> 			}
> 		],
> 		"connections": [
> 			{
> 				"fromId": "node_15",
> 				"toId": "node_13",
> 				"type": "Success"
> 			}
> 		]
> 	}
> }